### PR TITLE
Add TRAFRI Switch support - beta

### DIFF
--- a/fonctions.py
+++ b/fonctions.py
@@ -557,6 +557,34 @@ def ButtonconvertionTradfriRemote(val):
 
     return kwarg
 
+def ButtonconvertionTradfriSwitch(val):
+    kwarg = {}
+    val = str(val)
+
+    if val == '1002':
+        kwarg['nValue'] = 10
+    elif val == '1003':
+        kwarg['nValue'] = 20
+    elif val == '2002':
+        kwarg['nValue'] = 30
+    elif val == '2003':
+        kwarg['nValue'] = 40
+    elif val == '3002':
+        kwarg['nValue'] = 50
+    elif val == '4002':
+        kwarg['nValue'] = 60
+    elif val == '5002':
+        kwarg['nValue'] = 70
+    else:
+        kwarg['nValue'] = 0
+
+    if kwarg['nValue'] == 0:
+        kwarg['sValue'] = 'Off'
+    else:
+        kwarg['sValue'] = str( kwarg['nValue'] )
+
+    return kwarg
+
 def ButtonconvertionGeneric(val):
     kwarg = {}
     val = "%04d" % val

--- a/plugin.py
+++ b/plugin.py
@@ -56,7 +56,7 @@ except:
 
 from fonctions import rgb_to_xy, rgb_to_hsl, xy_to_rgb
 from fonctions import Count_Type, ProcessAllState, ProcessAllConfig, First_Json, JSON_Repair, get_JSON_payload
-from fonctions import ButtonconvertionXCUBE, ButtonconvertionXCUBE_R, ButtonconvertionTradfriRemote, ButtonconvertionGeneric, VibrationSensorConvertion
+from fonctions import ButtonconvertionXCUBE, ButtonconvertionXCUBE_R, ButtonconvertionTradfriRemote, ButtonconvertionTradfriSwitch, ButtonconvertionGeneric, VibrationSensorConvertion
 
 #from requests import async
 
@@ -454,6 +454,8 @@ class BasePlugin:
                     Type = 'Tradfri_remote'
                 #elif 'RWL021' in Model:
                 #    Type = 'Tradfri_remote'
+                elif 'TRADFRI on/off switch' in Model:
+                    Type = 'Tradfri_on/off_switch'
                 else:
                     Type = 'Switch_Generic'
 
@@ -650,6 +652,8 @@ class BasePlugin:
                     kwarg.update(ButtonconvertionXCUBE_R( state['buttonevent'] ) )
                 elif model == 'Tradfri_remote':
                     kwarg.update(ButtonconvertionTradfriRemote( state['buttonevent'] ) )
+                elif model == 'Tradfri_on/off_switch':
+                    kwarg.update(ButtonconvertionTradfriSwitch( state['buttonevent'] ) )
                 else:
                     kwarg.update(ButtonconvertionGeneric( state['buttonevent'] ) )
                 if IEEE not in self.NeedToReset:
@@ -661,17 +665,19 @@ class BasePlugin:
             if 'reachable' in state:
                 if state['reachable'] == True:
                     Unit = GetDomoDeviceInfo(IEEE)
-                    LUpdate = Devices[Unit].LastUpdate
-                    LUpdate=time.mktime(time.strptime(LUpdate,"%Y-%m-%d %H:%M:%S"))
-                    current = time.time()
+                    #Jump following action if Unit content is not valid
+                    if Unit != False:     
+                        LUpdate = Devices[Unit].LastUpdate
+                        LUpdate=time.mktime(time.strptime(LUpdate,"%Y-%m-%d %H:%M:%S"))
+                        current = time.time()
 
-                    if (SETTODEFAULT):
-                        #Check if the device has been see, at least 10 s ago
-                        if (current-LUpdate) > 10:
-                            Domoticz.Status("###### Device just re-connected : " + str(_Data) + "Set to defaut state")
-                            self.SetDeviceDefautState(IEEE,_Data['r'])
-                        else:
-                            Domoticz.Status("###### Device just re-connected : " + str(_Data) + "But ignored")
+                        if (SETTODEFAULT):
+                            #Check if the device has been see, at least 10 s ago
+                            if (current-LUpdate) > 10:
+                                Domoticz.Status("###### Device just re-connected : " + str(_Data) + "Set to defaut state")
+                                self.SetDeviceDefautState(IEEE,_Data['r'])
+                            else:
+                                Domoticz.Status("###### Device just re-connected : " + str(_Data) + "But ignored")
 
             if ('tampered' in state) or ('lowbattery' in state):
                 tampered = state.get('tampered',False)
@@ -1113,6 +1119,12 @@ def CreateDevice(IEEE,_Name,_Type):
         kwarg['Switchtype'] = 18
         kwarg['Image'] = 9
         kwarg['Options'] = {"LevelActions": "|||||", "LevelNames": "Off|On|More|Less|Right|Left", "LevelOffHidden": "true", "SelectorStyle": "0"}
+
+    elif _Type == 'Tradfri_on/off_switch':
+        kwarg['Type'] = 244
+        kwarg['Subtype'] = 62
+        kwarg['Switchtype'] = 18
+        kwarg['Options'] = {"LevelActions": "|||||", "LevelNames": "Off|B1C|B1L|B2C|B2L", "LevelOffHidden": "true", "SelectorStyle": "0"}
 
     elif _Type == 'XCube_C':
         kwarg['Type'] = 244


### PR DESCRIPTION
The switch generic profile does not work with the Ikea Tradfri Switch. This modification handle this kind of switch by supporting the short press and long press + release of the On and Off button

See the picture of the remote:
![tradfri-clicker_sq](https://user-images.githubusercontent.com/47904975/61825711-31148580-ae61-11e9-83a6-141d946f4acf.jpg)
