### PR TITLE
Add support for ZHABattery

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ To restart plugin : Tab "Hardware" > select the hardware "deCONZ" then click "Up
 - If your system doesn't support python "Request" lib, you can try older version < 1.0.9.    
 
 ## Changelog.
+- 25/06/20 : 1.0.14 > Handle the new websocket "attr", special widget for Xiaomi Aqara single gang (thx to @markiboy2all)
 - 28/05/20 : 1.0.13 > Delete banned_devices.txt from github, it will be created by the plugin, create specific widget for Aquara Opple and Xiaomi double gang (thx to @eserero), critic bug correction for Xiaomi plug (thx to @xxLeoxx93).
 - 27/01/20 : 1.0.12 > Correction for some Philips hue, correction for thermostat devices, change consumption widget for some devices, remove domoticz batterie alert if device have bad return for battery level, patch for group with UniqueId
 - 09/11/19 : 1.0.11 > All unknows devices will be recognized as on/off controler, because some working device have "Unknow" as type. Improving detection for fan and range extender. Adding Thermostat support (thx to @salopette). Adding support for long press on ikea remote. Reparation for Shutter control.   

--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ To restart plugin : Tab "Hardware" > select the hardware "deCONZ" then click "Up
 - If your system doesn't support python "Request" lib, you can try older version < 1.0.9.    
 
 ## Changelog.
-- 25/06/20 : 1.0.14 > Handle the new websocket "attr", special widget for Xiaomi Aqara single gang (thx to @markiboy2all)
+- 01/08/20 : 1.0.15 > Better support for Friend of HUE device. Disable error message about the gateway.
+- 25/06/20 : 1.0.14 > Handle the new websocket "attr", special widget for Xiaomi Aqara single gang (thx to @markiboy2all).
 - 28/05/20 : 1.0.13 > Delete banned_devices.txt from github, it will be created by the plugin, create specific widget for Aquara Opple and Xiaomi double gang (thx to @eserero), critic bug correction for Xiaomi plug (thx to @xxLeoxx93).
-- 27/01/20 : 1.0.12 > Correction for some Philips hue, correction for thermostat devices, change consumption widget for some devices, remove domoticz batterie alert if device have bad return for battery level, patch for group with UniqueId
+- 27/01/20 : 1.0.12 > Correction for some Philips hue, correction for thermostat devices, change consumption widget for some devices, remove domoticz batterie alert if device have bad return for battery level, patch for group with UniqueId.
 - 09/11/19 : 1.0.11 > All unknows devices will be recognized as on/off controler, because some working device have "Unknow" as type. Improving detection for fan and range extender. Adding Thermostat support (thx to @salopette). Adding support for long press on ikea remote. Reparation for Shutter control.   
 - 23/08/19 : 1.0.10 > Add message information for missing requests lib, make special device for "Tradfri on/off_switch" (thx @erwan2345). The plugin can now add itself missing groups after the starting. Another division by zero correction. Patch for virtual devices with same UniqueId.  
 - 20/06/19 : 1.0.9 > Compare database to check deleted devices. Code clean up. The plugin can now add itself missing devices after the starting. Trying to synchronise at start only if the gateway seem ready. Change request code (cf remark). Change Websocket code (thx @salopette).      

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ python3 API_KEY.py 127.0.0.1:80 create
 And for those who don't know where to find the API key and don't wana use the tool: https://dresden-elektronik.github.io/deconz-rest-doc/configuration/#aquireapikey
 
 ## Remark.
+- There is a deconz Discord channel https://discord.gg/QFhTxqN
+
 - Take care if you have too many devices, at startup, the plugin adds ALL your devices from deCONZ in domoticz (except those who are in banned file).
 
 - Finally, you can see more devices than you have in reality. This is normal, deCONZ can create more than 1 device for 1 real, and it can create for example 1 bulb + 2 switches just for 1 physical switch.

--- a/plugin.py
+++ b/plugin.py
@@ -1301,6 +1301,9 @@ def CreateDevice(IEEE,_Name,_Type):
         kwarg['Subtype'] = 62
         kwarg['Switchtype'] = 5
 
+    elif _Type == 'ZHABattery':
+        kwarg['TypeName'] = 'Percentage'
+
     elif _Type == 'CLIPGenericStatus':
         kwarg['TypeName'] = 'Text'
 


### PR DESCRIPTION
ZHABattery is used for IKEA FYRTUR blinds.