### PR TITLE
Add support for ZHABattery

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1301,6 +1301,9 @@ def CreateDevice(IEEE,_Name,_Type):
         kwarg['Subtype'] = 62
         kwarg['Switchtype'] = 5
 
+    elif _Type == 'ZHABattery':
+        kwarg['TypeName'] = 'Percentage'
+
     elif _Type == 'CLIPGenericStatus':
         kwarg['TypeName'] = 'Text'
 


### PR DESCRIPTION
ZHABattery is used for IKEA FYRTUR blinds.