### PR TITLE
Allow to treat unreachable lights as Off instead of On

### DIFF
--- a/fonctions.py
+++ b/fonctions.py
@@ -341,9 +341,9 @@ def ProcessAllConfig(data):
         if 'mode' in data:
             if not (data['mode'] == 'off' and data['on'] == True):
                 kwarg.update(ReturnUpdateValue( 'mode' , data['mode'] ) )
-    if 'reachable' in data:
-        if data['reachable'] == False:
-            kwarg.update({'TimedOut':1})
+    #if 'reachable' in data:
+    #    if data['reachable'] == False:
+    #        kwarg.update({'TimedOut':1})
 
     return kwarg
 
@@ -418,9 +418,9 @@ def ProcessAllState(data,model):
         kwarg.update(ReturnUpdateValue( 'any_on' , data['any_on'] ) )
 
     #Special
-    if 'reachable' in data:
-        if data['reachable'] == False:
-            kwarg.update({'TimedOut':1})
+    #if 'reachable' in data:
+    #    if data['reachable'] == False:
+    #        kwarg.update({'TimedOut':1})
 
     return kwarg
 

--- a/fonctions.py
+++ b/fonctions.py
@@ -341,9 +341,9 @@ def ProcessAllConfig(data):
         if 'mode' in data:
             if not (data['mode'] == 'off' and data['on'] == True):
                 kwarg.update(ReturnUpdateValue( 'mode' , data['mode'] ) )
-    #if 'reachable' in data:
-    #    if data['reachable'] == False:
-    #        kwarg.update({'TimedOut':1})
+    if 'reachable' in data:
+        if data['reachable'] == False:
+            kwarg.update({'TimedOut':1})
 
     return kwarg
 
@@ -418,9 +418,9 @@ def ProcessAllState(data,model):
         kwarg.update(ReturnUpdateValue( 'any_on' , data['any_on'] ) )
 
     #Special
-    #if 'reachable' in data:
-    #    if data['reachable'] == False:
-    #        kwarg.update({'TimedOut':1})
+    if 'reachable' in data:
+        if data['reachable'] == False:
+            kwarg.update({'TimedOut':1})
 
     return kwarg
 

--- a/plugin.py
+++ b/plugin.py
@@ -1261,6 +1261,9 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Log("Need update")
         if (Devices[Unit].Type == 241):
            Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
+           if kwarg['TimedOut'] == 1:
+              kwarg['nValue'] = 0
+			  kwarg['sValue'] = 'Off'
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -142,8 +142,7 @@ class BasePlugin:
             Domoticz.Debugging(int(Parameters["Mode3"]))
             #DumpConfigToLog()
             
-        if Parameters["Mode5"] == True:
-            self.ReachableOff = 1
+        if !Parameters["Mode5"]:
             Domoticz.Log("Treating unreachable as Off")
         #Read banned devices
         try:
@@ -1269,7 +1268,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
-        if self.ReachableOff == 1:
+        if  == 1:
             Domoticz.Log("Updating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))

--- a/plugin.py
+++ b/plugin.py
@@ -1270,7 +1270,7 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Debug("Need update")
         if  Parameters["Mode5"]:
             Domoticz.Log("Updating unreachable as off")
-            if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Switchtype == 7)):
+            if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].SubType == 73) and (Devices[Unit].SwitchType == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
                if kwarg.get('TimedOut',0) == 1:
                   kwarg['nValue'] = 0

--- a/plugin.py
+++ b/plugin.py
@@ -1266,12 +1266,12 @@ def UpdateDeviceProc(kwarg,Unit):
         kwarg['TimedOut'] = 0
 
     if NeedUpdate or not LIGHTLOG:
-        Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
+        Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
         if  Parameters["Mode5"] == "True":
-            Domoticz.Log("Updating unreachable as off")
+            Domoticz.Debug("Updating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].SubType == 73) and (Devices[Unit].SwitchType == 7)):
-               Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
+               Domoticz.Debug("Will handle Timeout like off args: " + str(kwarg))
                if kwarg.get('TimedOut',0) == 1:
                   kwarg['nValue'] = 0
                   kwarg['sValue'] = 'Off'

--- a/plugin.py
+++ b/plugin.py
@@ -142,7 +142,7 @@ class BasePlugin:
             Domoticz.Debugging(int(Parameters["Mode3"]))
             #DumpConfigToLog()
             
-        if Parameters["Mode5"]:
+        if Parameters["Mode5"] == "True":
             Domoticz.Log("Treating unreachable as Off")
         #Read banned devices
         try:
@@ -1268,7 +1268,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
-        if  Parameters["Mode5"]:
+        if  Parameters["Mode5"] == "True":
             Domoticz.Log("Updating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].SubType == 73) and (Devices[Unit].SwitchType == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))

--- a/plugin.py
+++ b/plugin.py
@@ -142,8 +142,8 @@ class BasePlugin:
             Domoticz.Debugging(int(Parameters["Mode3"]))
             #DumpConfigToLog()
             
-        if Parameters["Mode5"] != "0":
-            self.ReachableOff = int(Parameters["Mode5"])
+        if Parameters["Mode5"] == True:
+            self.ReachableOff = 1
             Domoticz.Log("Treating unreachable as Off")
         #Read banned devices
         try:

--- a/plugin.py
+++ b/plugin.py
@@ -1263,9 +1263,10 @@ def UpdateDeviceProc(kwarg,Unit):
         kwarg['TimedOut'] = 0
 
     if NeedUpdate or not LIGHTLOG:
-        Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
+        Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
         if Parameters["Mode5"] == True:
+            Domoticz.Log("Treating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
                if kwarg.get('TimedOut',0) == 1:

--- a/plugin.py
+++ b/plugin.py
@@ -142,7 +142,7 @@ class BasePlugin:
             Domoticz.Debugging(int(Parameters["Mode3"]))
             #DumpConfigToLog()
             
-        if !Parameters["Mode5"]:
+        if Parameters["Mode5"]:
             Domoticz.Log("Treating unreachable as Off")
         #Read banned devices
         try:

--- a/plugin.py
+++ b/plugin.py
@@ -1261,7 +1261,7 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Log("Need update")
         if (Devices[Unit].Type == 241):
            Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
-           if kwarg['TimedOut'] == 1:
+           if kwarg.get('TimedOut',0) == 1:
               kwarg['nValue'] = 0
               kwarg['sValue'] = 'Off'
         Devices[Unit].Update(**kwarg)

--- a/plugin.py
+++ b/plugin.py
@@ -723,6 +723,7 @@ class BasePlugin:
             if First_item == 'error':
                 Domoticz.Error("deCONZ error :" + str(_Data2))
                 if _Data2['error']['type'] == 3:
+					Domoticz.Log("Seems like disconnected")
                     dev = _Data2['error']['address'].split('/')
                     _id = dev[2]
                     _type = dev[1]

--- a/plugin.py
+++ b/plugin.py
@@ -1260,7 +1260,7 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Log("Need update")
         if (Devices[Unit].Type == 241):
-           Domoticz.Log("Will handle Timeout like off")
+           Domoticz.Log("Will handle Timeout like off args: " str(kwarg))
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -1268,7 +1268,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
-        if  == 1:
+        if  Parameters["Mode5"]:
             Domoticz.Log("Updating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))

--- a/plugin.py
+++ b/plugin.py
@@ -722,6 +722,7 @@ class BasePlugin:
             #Command Error
             if First_item == 'error':
                 Domoticz.Error("deCONZ error :" + str(_Data2))
+				Domoticz.Log("I'm here")
                 if _Data2['error']['type'] == 3:
 					Domoticz.Log("Seems like disconnected")
                     dev = _Data2['error']['address'].split('/')

--- a/plugin.py
+++ b/plugin.py
@@ -41,8 +41,8 @@
         </param>
         <param field="Mode5" label="Treat disconnected as off" width="150px">
             <options>
-                <option label="True" value="True"/>
-                <option label="False" value="False"  default="true" />
+                <option label="True" value="1"/>
+                <option label="False" value="0"  default="true" />
             </options>
         </param>
     </params>
@@ -1265,7 +1265,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
-        if Parameters["Mode5"] == True:
+        if Parameters["Mode5"] == 1:
             Domoticz.Log("Treating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))

--- a/plugin.py
+++ b/plugin.py
@@ -722,9 +722,9 @@ class BasePlugin:
             #Command Error
             if First_item == 'error':
                 Domoticz.Error("deCONZ error :" + str(_Data2))
-				Domoticz.Log("I'm here")
+                #Domoticz.Log("I'm here")
                 if _Data2['error']['type'] == 3:
-					Domoticz.Log("Seems like disconnected")
+                    #Domoticz.Log("Seems like disconnected")
                     dev = _Data2['error']['address'].split('/')
                     _id = dev[2]
                     _type = dev[1]

--- a/plugin.py
+++ b/plugin.py
@@ -39,6 +39,12 @@
                 <option label="All" value="-1"/>
             </options>
         </param>
+        <param field="Mode5" label="Treat disconnected as off" width="150px">
+            <options>
+                <option label="True" value="True"/>
+                <option label="False" value="False"  default="true" />
+            </options>
+        </param>
     </params>
 </plugin>
 """
@@ -1258,12 +1264,13 @@ def UpdateDeviceProc(kwarg,Unit):
 
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
-        Domoticz.Log("Need update")
-        if (Devices[Unit].Type == 241) or (Devices[Unit].Type == 244):
-           Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
-           if kwarg.get('TimedOut',0) == 1:
-              kwarg['nValue'] = 0
-              kwarg['sValue'] = 'Off'
+        Domoticz.Debug("Need update")
+        if Parameters["Mode5"] == True:
+            if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
+               Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
+               if kwarg.get('TimedOut',0) == 1:
+                  kwarg['nValue'] = 0
+                  kwarg['sValue'] = 'Off'
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -722,9 +722,9 @@ class BasePlugin:
             #Command Error
             if First_item == 'error':
                 Domoticz.Error("deCONZ error :" + str(_Data2))
-                #Domoticz.Log("I'm here")
+                Domoticz.Log("Command for type: " + str(_type))
                 if _Data2['error']['type'] == 3:
-                    Domoticz.Log("Seems like disconnected type") + str(_Type)
+                    Domoticz.Log("Seems like disconnected type") + str(_type)
                     dev = _Data2['error']['address'].split('/')
                     _id = dev[2]
                     _type = dev[1]

--- a/plugin.py
+++ b/plugin.py
@@ -1259,7 +1259,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Log("Need update")
-        if (Devices[Unit].Type == 241):
+        if (Devices[Unit].Type == 241) or (Device[Unit].Type == 244):
            Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
            if kwarg.get('TimedOut',0) == 1:
               kwarg['nValue'] = 0

--- a/plugin.py
+++ b/plugin.py
@@ -41,8 +41,8 @@
         </param>
         <param field="Mode5" label="Treat disconnected as off" width="150px">
             <options>
-                <option label="True" value="1"/>
-                <option label="False" value="0"  default="true" />
+                <option label="True" value="True"/>
+                <option label="False" value="False"  default="true" />
             </options>
         </param>
     </params>
@@ -1270,7 +1270,7 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Debug("Need update")
         if  Parameters["Mode5"]:
             Domoticz.Log("Updating unreachable as off")
-            if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
+            if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
                if kwarg.get('TimedOut',0) == 1:
                   kwarg['nValue'] = 0

--- a/plugin.py
+++ b/plugin.py
@@ -1258,6 +1258,9 @@ def UpdateDeviceProc(kwarg,Unit):
 
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
+        Domoticz.Log("Need update")
+        if (Devices[Unit].Type == 241):
+           Domoticz.Log("Will handle Timeout like off")
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -1259,7 +1259,7 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Log("Need update")
-        if (Devices[Unit].Type == 241) or (Device[Unit].Type == 244):
+        if (Devices[Unit].Type == 241) or (Devices[Unit].Type == 244):
            Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
            if kwarg.get('TimedOut',0) == 1:
               kwarg['nValue'] = 0

--- a/plugin.py
+++ b/plugin.py
@@ -1260,7 +1260,7 @@ def UpdateDeviceProc(kwarg,Unit):
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Log("Need update")
         if (Devices[Unit].Type == 241):
-           Domoticz.Log("Will handle Timeout like off args: " str(kwarg))
+           Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -724,7 +724,7 @@ class BasePlugin:
                 Domoticz.Error("deCONZ error :" + str(_Data2))
                 #Domoticz.Log("I'm here")
                 if _Data2['error']['type'] == 3:
-                    #Domoticz.Log("Seems like disconnected")
+                    Domoticz.Log("Seems like disconnected type") + str(_Type)
                     dev = _Data2['error']['address'].split('/')
                     _id = dev[2]
                     _type = dev[1]

--- a/plugin.py
+++ b/plugin.py
@@ -1263,7 +1263,7 @@ def UpdateDeviceProc(kwarg,Unit):
            Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
            if kwarg['TimedOut'] == 1:
               kwarg['nValue'] = 0
-			  kwarg['sValue'] = 'Off'
+              kwarg['sValue'] = 'Off'
         Devices[Unit].Update(**kwarg)
     else:
         Domoticz.Debug("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg) + ", IGNORED , no changes !")

--- a/plugin.py
+++ b/plugin.py
@@ -108,6 +108,7 @@ class BasePlugin:
         self.Banned_Devices = []
         self.BufferReceive = ''
         self.BufferLenght = 0
+        self.ReachableOff = 0
 
         self.IDGateway = -1
 
@@ -140,7 +141,10 @@ class BasePlugin:
         if Parameters["Mode3"] != "0":
             Domoticz.Debugging(int(Parameters["Mode3"]))
             #DumpConfigToLog()
-
+            
+        if Parameters["Mode5"] != "0":
+            self.ReachableOff = int(Parameters["Mode5"])
+            Domoticz.Log("Treating unreachable as Off")
         #Read banned devices
         try:
             with open(Parameters["HomeFolder"]+"banned_devices.txt", 'r') as myPluginConfFile:
@@ -1265,8 +1269,8 @@ def UpdateDeviceProc(kwarg,Unit):
     if NeedUpdate or not LIGHTLOG:
         Domoticz.Log("### Update  device ("+Devices[Unit].Name+") : " + str(kwarg))
         Domoticz.Debug("Need update")
-        if Parameters["Mode5"] == 1:
-            Domoticz.Log("Treating unreachable as off")
+        if self.ReachableOff == 1:
+            Domoticz.Log("Updating unreachable as off")
             if (Devices[Unit].Type == 241) or ((Devices[Unit].Type == 244) and (Devices[Unit].Subtype == 73) and (Devices[Unit].Switchtype == 7)):
                Domoticz.Log("Will handle Timeout like off args: " + str(kwarg))
                if kwarg.get('TimedOut',0) == 1:


### PR DESCRIPTION
As many other people, I do have real switch with connected bulb. And I was not happy with the actual solution which is treating unreachable bulb as On, so I modified your plugin to add a parameter to switch the behaviour.

By default it stay the same, but if you activate this parameter and the bulb will treated as Off when unreachable.

I hope you will find this useful.