### PR TITLE
Add compatibility with Xiaomi Cube T1 & Pro T1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ To restart plugin : Tab "Hardware" > select the hardware "deCONZ" then click "Up
 - If your system doesn't support python "Request" lib, you can try older version < 1.0.9.    
 
 ## Changelog.
+- 12/06/22 : 1.0.26 > Make the widget for covering work again, following the Domoticz update. Create a widget with consumption and power for some devices that are able to support it, (thx @BabaIsYou)
 - 10/09/22 : 1.0.25 > It's now possible to clean the unused API key used for Hue Essentials, add support for binary module, with the develco one, add "pulseconfiguration" as possible setting in the GUI, thx @Jemand .   
 - Correct an issue for thermostat with "mode" not updated.
 - 08/05/22 : 1.0.24 > This version contain various correctives for consumption/power sensors.   

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ python3 API_KEY.py 127.0.0.1:80 create
 And for those who don't know where to find the API key and don't wana use the tool: https://dresden-elektronik.github.io/deconz-rest-doc/getting_started/#acquire-an-api-key    
 Or you can just use the Front End in Domoticz/Custom/Deconz.   
 
-- By defaut the plugin use standard setting, you can use special one in the field "specials settings" on the hardware panel, for exemple ENABLEMORESENSOR will enable tension and current sensors.   
+- By defaut the plugin use standard setting, you can use special one in the field "specials settings" on the hardware panel, available setting are :   
+
+| Option 	| action |
+|---	|---	|
+| ENABLEMORESENSOR | enable tension and current sensors	|
+| ENABLEBATTERYWIDGET	| create a  special widget by device just for battery |
+
 
 ## Remark.
 - There is a deconz Discord channel https://discord.gg/QFhTxqN
@@ -111,7 +117,8 @@ To restart plugin : Tab "Hardware" > select the hardware "deCONZ" then click "Up
 - If your system doesn't support python "Request" lib, you can try older version < 1.0.9.    
 
 ## Changelog.
-- 12/06/22 : 1.0.26 > Make the widget for covering work again, following the Domoticz update. Create a widget with consumption and power for some devices that are able to support it, (thx @BabaIsYou)
+- 17/02/23 : 1.0.27 > Add special support for the Ikea Starkvind thx @arjannv , add support for the Alarm System, and the support for keypad, see https://github.com/Smanar/Domoticz-deCONZ/wiki/How-to-add-keypad-to-domoticz thx @BabaIsYou , add new option ENABLEBATTERYWIDGET ,remove "capabilities" error message.   
+- 12/11/22 : 1.0.26 > Make the widget for covering work again, following the Domoticz update. Create a widget with consumption and power for some devices that are able to support it, (thx @BabaIsYou)
 - 10/09/22 : 1.0.25 > It's now possible to clean the unused API key used for Hue Essentials, add support for binary module, with the develco one, add "pulseconfiguration" as possible setting in the GUI, thx @Jemand .   
 - Correct an issue for thermostat with "mode" not updated.
 - 08/05/22 : 1.0.24 > This version contain various correctives for consumption/power sensors.   

--- a/plugin.py
+++ b/plugin.py
@@ -626,7 +626,28 @@ class BasePlugin:
                 #ignore ZHASwitch if vibration sensor
                 if 'sensitivity' in ConfigList:
                     return
-                if 'lumi.sensor_cube' in Model:
+                
+                #Used by Xiaomi Cube T1
+                if 'lumi.remote.cagl01' in Model:
+                    if IEEE.endswith('-03-000c'):
+                        Type = 'XCube_R'
+                    elif IEEE.endswith('-02-0012'):
+                        Type = 'XCube_C'
+                    else:
+                        # Useless device
+                        self.Devices[IEEE]['state'] = 'banned'
+                        return
+                #Used by Xiaomi Cube Pro T1
+                elif 'lumi.remote.cagl02' in Model:
+                    if IEEE.endswith('-03-000c'):
+                        Type = 'XCube_R'
+                    elif IEEE.endswith('-02-0012'):
+                        Type = 'XCube_C'
+                    else:
+                        # Useless device
+                        self.Devices[IEEE]['state'] = 'banned'
+                        return
+                elif 'lumi.sensor_cube' in Model:
                     if IEEE.endswith('-03-000c'):
                         Type = 'XCube_R'
                     elif IEEE.endswith('-02-0012'):

--- a/plugin.py
+++ b/plugin.py
@@ -1033,6 +1033,10 @@ class BasePlugin:
         elif 'attr' in _Data:
             attr = _Data['attr']
 
+        #MAJ capabilities, not used yet
+        elif 'capabilities' in _Data:
+            capabilities = _Data['capabilities']
+
         else:
             Domoticz.Error("Unknow MAJ: " + str(_Data) )
 


### PR DESCRIPTION
The new Aqara Cube T1 & Pro T1 has a model id "lumi.remote.cagl01/cagl02".
Those have been recently added in deconz-rest-plugin  https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5838

I kept XCube_R/XCube_C for the main branch.

But for my personal needs, I defined specific XCubeProT1_R/XCubeProT1_C (also the conversion functions in function.py).
As I prefer to keep the main branch clean, I refrain from pulling those modifications. 