### PR TITLE
Compatibility with Xiaomi Aqara Cube T1/T1 Pro

### DIFF
--- a/fonctions.py
+++ b/fonctions.py
@@ -803,22 +803,22 @@ def ButtonconvertionXCUBEPROT1(val, gesture):
     face = str(val)
     v = 0
 
-    if gest == 0: # wake
-        v = 70
-    elif gest == 1:# shake
-        v = 10
-    elif gest == 2:# Free Fall
+    if gest == 0:             # wake
         v = 20
-    elif gest == 3:# 90 flip 
-        v = 30 + int(face[0]) #add face up number
-    elif gest == 4:# 180 flip
+    elif gest == 1:           # shake
+        v = 10
+    elif gest == 2:           # Drop
+        v = 30
+    elif gest == 3:           # 90 flip 
         v = 40 + int(face[0]) #add face up number
-    elif gest == 5:# push
+    elif gest == 4:           # 180 flip
         v = 50 + int(face[0]) #add face up number
-    elif gest == 6:# double tap
+    elif gest == 5:           # push
         v = 60 + int(face[0]) #add face up number
-    else:# Unknown
-        v = 80
+    elif gest == 6:           # double tap
+        v = 70 + int(face[0]) #add face up number
+    else:                     # Unknown
+        v = 0
 
     if v == 0:
         kwarg['sValue'] = 'Off'

--- a/fonctions.py
+++ b/fonctions.py
@@ -756,7 +756,7 @@ def ButtonconvertionXCUBE_R(val):
 
     return kwarg
 
-def ButtonconvertionXCUBEPROT1_R(val):
+def ButtonconvertionXCUBET1_R(val):
     kwarg = {}
 
     kwarg['nValue'] = int(val)
@@ -797,7 +797,7 @@ def ButtonconvertionXCUBE(val):
 
     return kwarg
 
-def ButtonconvertionXCUBEPROT1(val, gesture):
+def ButtonconvertionXCUBET1(val, gesture):
     kwarg = {}
     gest = int(gesture)
     face = str(val)
@@ -810,13 +810,13 @@ def ButtonconvertionXCUBEPROT1(val, gesture):
     elif gest == 2:           # Drop
         v = 30
     elif gest == 3:           # 90 flip 
-        v = 40 + int(face[0]) #add face up number
+        v = 40
     elif gest == 4:           # 180 flip
-        v = 50 + int(face[0]) #add face up number
+        v = 50
     elif gest == 5:           # push
-        v = 60 + int(face[0]) #add face up number
+        v = 60
     elif gest == 6:           # double tap
-        v = 70 + int(face[0]) #add face up number
+        v = 70
     else:                     # Unknown
         v = 0
 

--- a/fonctions.py
+++ b/fonctions.py
@@ -756,6 +756,18 @@ def ButtonconvertionXCUBE_R(val):
 
     return kwarg
 
+def ButtonconvertionXCUBEPROT1_R(val):
+    kwarg = {}
+
+    kwarg['nValue'] = int(val)
+
+    if kwarg['nValue'] == 0:
+        kwarg['sValue'] = 'Off'
+    else:
+        kwarg['sValue'] = str( kwarg['nValue'] )
+
+    return kwarg
+
 def ButtonconvertionXCUBE(val):
     kwarg = {}
     val = str(val)
@@ -782,6 +794,38 @@ def ButtonconvertionXCUBE(val):
         kwarg['sValue'] = str( v )
 
     kwarg['nValue'] = int(val)
+
+    return kwarg
+
+def ButtonconvertionXCUBEPROT1(val, gesture):
+    kwarg = {}
+    gest = int(gesture)
+    face = str(val)
+    v = 0
+
+    if gest == 0: # wake
+        v = 70
+    elif gest == 1:# shake
+        v = 10
+    elif gest == 2:# Free Fall
+        v = 20
+    elif gest == 3:# 90 flip 
+        v = 30 + int(face[0]) #add face up number
+    elif gest == 4:# 180 flip
+        v = 40 + int(face[0]) #add face up number
+    elif gest == 5:# push
+        v = 50 + int(face[0]) #add face up number
+    elif gest == 6:# double tap
+        v = 60 + int(face[0]) #add face up number
+    else:# Unknown
+        v = 80
+
+    if v == 0:
+        kwarg['sValue'] = 'Off'
+    else:
+        kwarg['sValue'] = str( v )
+
+    kwarg['nValue'] = v
 
     return kwarg
 

--- a/plugin.py
+++ b/plugin.py
@@ -64,6 +64,7 @@ except:
 from fonctions import rgb_to_xy, rgb_to_hsv, xy_to_rgb
 from fonctions import Count_Type, ProcessAllState, ProcessAllConfig, First_Json, JSON_Repair, get_JSON_payload
 from fonctions import ButtonconvertionXCUBE, ButtonconvertionXCUBE_R, ButtonconvertionTradfriRemote, ButtonconvertionTradfriSwitch
+from fonctions import ButtonconvertionXCUBEPROT1, ButtonconvertionXCUBEPROT1_R
 from fonctions import ButtonConvertion, VibrationSensorConvertion
 from fonctions import installFE, uninstallFE
 from widget import Createdatawidget
@@ -641,7 +642,17 @@ class BasePlugin:
                 #ignore ZHASwitch if vibration sensor
                 if 'sensitivity' in ConfigList:
                     return
-                if 'lumi.sensor_cube' in Model:
+                #Used by Xiaomi Cube Pro T1
+                if 'lumi.remote.cagl02' in Model:
+                    if IEEE.endswith('-03-000c'):
+                        Type = 'XCubeProT1_R'
+                    elif IEEE.endswith('-02-0012'):
+                        Type = 'XCubeProT1_C'
+                    else:
+                        # Useless device
+                        self.Devices[IEEE]['state'] = 'banned'
+                        return
+                elif 'lumi.sensor_cube' in Model:
                     if IEEE.endswith('-03-000c'):
                         Type = 'XCube_R'
                     elif IEEE.endswith('-02-0012'):
@@ -989,6 +1000,10 @@ class BasePlugin:
                     kwarg.update(ButtonconvertionXCUBE(state['buttonevent']) )
                 elif model == 'XCube_R':
                     kwarg.update(ButtonconvertionXCUBE_R(state['buttonevent']) )
+                elif model == 'XCubeProT1_C':
+                    kwarg.update(ButtonconvertionXCUBEPROT1(state['buttonevent'], state['gesture']) )
+                elif model == 'XCubeProT1_R':
+                    kwarg.update(ButtonconvertionXCUBEPROT1_R(state['buttonevent']) )
                 elif model == 'Tradfri_remote':
                     kwarg.update(ButtonconvertionTradfriRemote(state['buttonevent']) )
                 elif model == 'Tradfri_on/off_switch':

--- a/plugin.py
+++ b/plugin.py
@@ -64,7 +64,7 @@ except:
 from fonctions import rgb_to_xy, rgb_to_hsv, xy_to_rgb
 from fonctions import Count_Type, ProcessAllState, ProcessAllConfig, First_Json, JSON_Repair, get_JSON_payload
 from fonctions import ButtonconvertionXCUBE, ButtonconvertionXCUBE_R, ButtonconvertionTradfriRemote, ButtonconvertionTradfriSwitch
-from fonctions import ButtonconvertionXCUBEPROT1, ButtonconvertionXCUBEPROT1_R
+from fonctions import ButtonconvertionXCUBET1, ButtonconvertionXCUBET1_R
 from fonctions import ButtonConvertion, VibrationSensorConvertion
 from fonctions import installFE, uninstallFE
 from widget import Createdatawidget
@@ -642,12 +642,22 @@ class BasePlugin:
                 #ignore ZHASwitch if vibration sensor
                 if 'sensitivity' in ConfigList:
                     return
-                #Used by Xiaomi Cube Pro T1
-                if 'lumi.remote.cagl02' in Model:
+                #Used by Xiaomi Cube T1
+                if 'lumi.remote.cagl01' in Model:
                     if IEEE.endswith('-03-000c'):
-                        Type = 'XCubeProT1_R'
+                        Type = 'XCubeT1_R'
                     elif IEEE.endswith('-02-0012'):
-                        Type = 'XCubeProT1_C'
+                        Type = 'XCubeT1_C'
+                    else:
+                        # Useless device
+                        self.Devices[IEEE]['state'] = 'banned'
+                        return
+                #Used by Xiaomi Cube T1 Pro
+                elif 'lumi.remote.cagl02' in Model:
+                    if IEEE.endswith('-03-000c'):
+                        Type = 'XCubeT1_R'
+                    elif IEEE.endswith('-02-0012'):
+                        Type = 'XCubeT1_C'
                     else:
                         # Useless device
                         self.Devices[IEEE]['state'] = 'banned'
@@ -1000,10 +1010,10 @@ class BasePlugin:
                     kwarg.update(ButtonconvertionXCUBE(state['buttonevent']) )
                 elif model == 'XCube_R':
                     kwarg.update(ButtonconvertionXCUBE_R(state['buttonevent']) )
-                elif model == 'XCubeProT1_C':
-                    kwarg.update(ButtonconvertionXCUBEPROT1(state['buttonevent'], state['gesture']) )
-                elif model == 'XCubeProT1_R':
-                    kwarg.update(ButtonconvertionXCUBEPROT1_R(state['buttonevent']) )
+                elif model == 'XCubeT1_C':
+                    kwarg.update(ButtonconvertionXCUBET1(state['buttonevent'], state['gesture']) )
+                elif model == 'XCubeT1_R':
+                    kwarg.update(ButtonconvertionXCUBET1_R(state['buttonevent']) )
                 elif model == 'Tradfri_remote':
                     kwarg.update(ButtonconvertionTradfriRemote(state['buttonevent']) )
                 elif model == 'Tradfri_on/off_switch':


### PR DESCRIPTION
Xiaomi Aqara Cube T1 and T1 pro recently added in deconz-rest-api: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5838

Detect new model id:
- lumi.remote.cagl01: Xiaomi Aqara Cube T1
- lumi.remote.cagl02: Xiaomi Aqara Cube T1 Pro

Assign new type: XCubeT1_C / XCubeT1_R

Add two new conversion functions for the Xiaomi Aqara Cube T1 pro
- ButtonconvertionXCUBEPROT1_R: Same as Xiaomi cube
- ButtonconvertionXCUBEPROT1: uses 'gesture' and 'buttonevent' (button event can be used to return more complex values containing the last action and cube face being up)