### PR TITLE
[Aqara Cube Pro T1] Returned state improvement

### DIFF
--- a/fonctions.py
+++ b/fonctions.py
@@ -855,6 +855,38 @@ def ButtonconvertionXCUBET1(val, gesture):
 
     return kwarg
 
+def ButtonconvertionXCUBEPROT1(val, gesture):
+    kwarg = {}
+    gest = int(gesture)
+    face = str(val)
+    v = 0
+
+    if gest == 0:             # wake
+        v = 70
+    elif gest == 1:           # shake
+        v = 80
+    elif gest == 2:           # Free Fall
+        v = 110
+    elif gest == 3:           # 90 flip
+        v = int(face[0]) * 10 #add face up number
+    elif gest == 4:           # 180 flip
+        v = int(face[0]) * 10 #add face up number
+    elif gest == 5:           # push
+        v = 90
+    elif gest == 6:           # double tap
+        v = 100
+    else:# Unknown
+        v = 0
+
+    if v == 0:
+        kwarg['sValue'] = 'Off'
+    else:
+        kwarg['sValue'] = str( v )
+
+    kwarg['nValue'] = v
+
+    return kwarg
+
 # <=4002 >=5002 +=2002 -=3002 4001/5001/2001/3001
 def ButtonconvertionTradfriRemote(val):
     kwarg = {}

--- a/plugin.py
+++ b/plugin.py
@@ -65,6 +65,7 @@ from fonctions import rgb_to_xy, rgb_to_hsv, xy_to_rgb
 from fonctions import Count_Type, ProcessAllState, ProcessAllConfig, First_Json, JSON_Repair, get_JSON_payload
 from fonctions import ButtonconvertionXCUBE, ButtonconvertionXCUBE_R, ButtonconvertionTradfriRemote, ButtonconvertionTradfriSwitch
 from fonctions import ButtonconvertionXCUBET1, ButtonconvertionXCUBET1_R
+from fonctions import ButtonconvertionXCUBEPROT1
 from fonctions import ButtonConvertion, VibrationSensorConvertion
 from fonctions import installFE, uninstallFE
 from widget import Createdatawidget
@@ -674,9 +675,9 @@ class BasePlugin:
                 #Used by Xiaomi Cube T1 Pro
                 elif 'lumi.remote.cagl02' in Model:
                     if IEEE.endswith('-03-000c'):
-                        Type = 'XCubeT1_R'
+                        Type = 'XCubeProT1_R'
                     elif IEEE.endswith('-02-0012'):
-                        Type = 'XCubeT1_C'
+                        Type = 'XCubeProT1_C'
                     else:
                         # Useless device
                         self.Devices[IEEE]['state'] = 'banned'
@@ -1043,6 +1044,10 @@ class BasePlugin:
                 elif model == 'XCubeT1_C':
                     kwarg.update(ButtonconvertionXCUBET1(state['buttonevent'], state['gesture']) )
                 elif model == 'XCubeT1_R':
+                    kwarg.update(ButtonconvertionXCUBET1_R(state['buttonevent']) )
+                elif model == 'XCubeProT1_C':
+                    kwarg.update(ButtonconvertionXCUBEPROT1(state['buttonevent'], state['gesture']) )
+                elif model == 'XCubeProT1_R':
                     kwarg.update(ButtonconvertionXCUBET1_R(state['buttonevent']) )
                 elif model == 'Tradfri_remote':
                     kwarg.update(ButtonconvertionTradfriRemote(state['buttonevent']) )

--- a/widget.py
+++ b/widget.py
@@ -258,7 +258,18 @@ def Createdatawidget(IEEE, _Name, _Type, opt):
         kwarg['Image'] = 9
         kwarg['Options'] = {"LevelActions": "||||||||", "LevelNames": "Off|Shak|Wake|Drop|90°|180°|Push|Tap", "LevelOffHidden": "true", "SelectorStyle": "0"}
 
+    elif _Type == 'XCubeProT1_C':
+        kwarg['Type'] = 244
+        kwarg['Subtype'] = 62
+        kwarg['Switchtype'] = 18
+        kwarg['Image'] = 9
+        kwarg['Options'] = {"LevelActions": "||||||||||||", "LevelNames": "Off|F1|F2|F3|F4|F5|F6|Wake|Shake|Push|Tap|Drop", "LevelOffHidden": "true", "SelectorStyle": "0"}
+
     elif _Type == 'XCube_R':
+        kwarg['TypeName'] = 'Custom'
+        kwarg['Options'] = {"Custom": ("1;degree")}
+
+    elif _Type == 'XCubeProT1_R':
         kwarg['TypeName'] = 'Custom'
         kwarg['Options'] = {"Custom": ("1;degree")}
 


### PR DESCRIPTION
The current implementation of the AQARA Cube Pro T1 has room for improvement. 

This pull request proposes to remap the widget returned state as follows:
- 0: Off
- 10/20/30/40/50/60: Cube face being up after a 90° or 180° flip (10 = Face 1, 20 = Face 2, ...)
- 70: Wake
- 80: Shake
- 90: Push
- 100: Double tap
- 110: Free fall

This upgrade allows advanced scripting such as mode selection by flipping the cube on a specific face, then mode activation or modification by shaking, double tap, or rotation.

If accepted, users need to update their scripts or scenes because of the difference in the state's value.